### PR TITLE
Fix for signal recursive call deadlock

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class DbusCXX(ConanFile):
 
     def source(self):
         git = Git(self)
-        git.clone(url="https://github.com/strainmike/dbus-cxx.git", target=".")
+        git.clone(url="https://github.com/alynch-ni/dbus-cxx.git", target=".")
         # Please, be aware that using the head of the branch instead of an immutable tag
         # or commit is not a good practice in general
         git.checkout("conan-windows")

--- a/dbus-cxx/connection.cpp
+++ b/dbus-cxx/connection.cpp
@@ -708,7 +708,8 @@ void Connection::process_call_message( std::shared_ptr<const CallMessage> callms
 void Connection::process_signal_message( std::shared_ptr<const SignalMessage> msg ) {
     {
         // See if any of our free handlers can handle this
-        std::unique_lock<std::mutex> lock( m_priv->m_freeProxySignalsLock );
+        std::unique_lock<std::mutex> lock( m_priv->m_freeProxySignalsLock, std::try_to_lock );
+        if ( !lock.owns_lock() ) return;
 
         for( FreeSignalThreadInfo& sigInfo : m_priv->m_freeProxySignals ) {
             if( sigInfo.handlingThread != m_priv->m_dispatchingThread ){


### PR DESCRIPTION
This change prevents a deadlock when a signal is received while sending a signal in a signal handler. It puts off handling the incoming signal until the next time the dispatcher is invoked. 

Don't actually merge the second commit.