### PR TITLE
Fix deadlock and update conan build to remove hard-coded branch

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,14 +9,7 @@ class DbusCXX(ConanFile):
     generators = "CMakeDeps"
 
     default_options = {"libuv/(*:static": True}
-
-
-    def source(self):
-        git = Git(self)
-        git.clone(url="https://github.com/strainmike/dbus-cxx.git", target=".")
-        # Please, be aware that using the head of the branch instead of an immutable tag
-        # or commit is not a good practice in general
-        git.checkout("conan-windows")
+    exports_sources = "*"
 
     def requirements(self):
         self.requires("libsigcpp/3.0.7")

--- a/dbus-cxx/connection.cpp
+++ b/dbus-cxx/connection.cpp
@@ -708,7 +708,8 @@ void Connection::process_call_message( std::shared_ptr<const CallMessage> callms
 void Connection::process_signal_message( std::shared_ptr<const SignalMessage> msg ) {
     {
         // See if any of our free handlers can handle this
-        std::unique_lock<std::mutex> lock( m_priv->m_freeProxySignalsLock );
+        std::unique_lock<std::mutex> lock( m_priv->m_freeProxySignalsLock, std::try_to_lock );
+        if ( !lock.owns_lock() ) return;
 
         for( FreeSignalThreadInfo& sigInfo : m_priv->m_freeProxySignals ) {
             if( sigInfo.handlingThread != m_priv->m_dispatchingThread ){


### PR DESCRIPTION
This includes two fixes:

Prevent a deadlock condition when a signal handler emits a signal while an incoming signal comes in to be handled by deferring the processing of the incoming signal.

Remove the hard-coded branch and repo from the conan build. Now the version that is synced will be built.